### PR TITLE
requirements.txt: use pyrogram v0.18.0 to fix flood wait exceptions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ python-dotenv>=0.10
 tenacity>=6.0.0
 python-magic
 beautifulsoup4>=4.8.2,<4.8.10
-Pyrogram>=0.16.0,<0.16.10
+Pyrogram==0.18.0
 TgCrypto>=1.1.1,<1.1.10
 git+https://gitlab.com/magneto261290/youtube-dl
 lxml


### PR DESCRIPTION
pyrogram.client.client - ERROR - [420 FLOOD_WAIT_X]: A wait of 3 seconds is required (caused by "upload.GetFile")

this exceptions was fixed in the following commit in v0.18.0
https://github.com/pyrogram/pyrogram/commit/99aee987bdc0154c875c3072cf368f4e9c31aee3